### PR TITLE
feat: add sysinfo endpoint

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -20,9 +20,9 @@
 # Portal Personnel API configurations #
 #######################################
 export S3_BUCKET_NAME='test_bucket'
-export AWS_DEFAULT_REGION='test_region'
-export AWS_ACCESS_KEY_ID='thiscanbeanything'
-export AWS_SECRET_ACCESS_KEY='thiscanbeanything'
+export S3_REGION='test_region'
+export S3_ACCESS_KEY_ID='thiscanbeanything'
+export S3_SECRET_ACCESS_KEY='thiscanbeanything'
 
 ################################
 # Docker compose configuration #

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start": "node ./dist/index.js",
     "dev": "concurrently --kill-others \"yarn compile --watch\" \"nodemon ./dist/index.js\"",
     "docker:build": "docker build -t ussf-personnel-api .",
-    "docker:start": "docker run --rm -it --env AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY --env S3_BUCKET_NAME=$S3_BUCKET_NAME -p 4000:4000 --volume ./spreadsheets:/app/spreadsheets ussf-personnel-api",
+    "docker:start": "docker run --rm -it --env S3_REGION=$S3_REGION --env S3_ACCESS_KEY_ID=$S3_ACCESS_KEY_ID --env S3_SECRET_ACCESS_KEY=$S3_SECRET_ACCESS_KEY --env S3_BUCKET_NAME=$S3_BUCKET_NAME -p 4000:4000 --volume ./spreadsheets:/app/spreadsheets ussf-personnel-api",
     "start-docker": "yarn docker:build && yarn docker:start"
   },
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "dependencies": {
     "@apollo/server": "4.7.5",
     "@aws-sdk/client-s3": "3.32.0",
+    "body-parser": "1.20.2",
+    "cors": "2.8.5",
     "exceljs": "4.3.0",
+    "express": "4.18.2",
     "graphql": "16.7.1",
     "graphql-tag": "2.12.6",
     "luxon": "3.3.0"
@@ -22,6 +25,7 @@
   "type": "module",
   "devDependencies": {
     "@aws-sdk/types": "3.370.0",
+    "@types/cors": "2.8.14",
     "@types/luxon": "3.3.1",
     "@types/node": "20.4.2",
     "concurrently": "8.2.0",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,7 +5,13 @@ import { enlistedFilename, enlistedRanks, officerFilename, officerRanks } from "
 import { Stream } from "stream";
 
 const getS3Client = () => {
-  return new S3Client({ region: process.env.AWS_DEFAULT_REGION });
+  return new S3Client({
+    region: process.env.S3_REGION,
+    credentials: {
+      accessKeyId: process.env.S3_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
+    }
+  });
 };
 
 const getWorksheet = async (filename: string) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,52 @@
-import { ApolloServer } from "@apollo/server"
-import { startStandaloneServer } from "@apollo/server/standalone"
+import { ApolloServer } from '@apollo/server';
+import { expressMiddleware } from '@apollo/server/express4';
+import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer';
+import express from 'express';
+import http from 'http';
+import cors from 'cors';
+import bodyParser from 'body-parser';
 import { resolvers } from "./resolvers.js"
 import { typeDefs } from "./schema.js"
 
-const server = new ApolloServer({ typeDefs, resolvers })
+interface MyContext {
+  token?: string;
+}
 
-const { url } = await startStandaloneServer(server, { listen: { port: 4000 }})
+// Required logic for integrating with Express
+const app = express();
+// Our httpServer handles incoming requests to our Express app.
+// Below, we tell Apollo Server to "drain" this httpServer,
+// enabling our servers to shut down gracefully.
+const httpServer = http.createServer(app);
 
-console.log(`🚀 Server ready at: ${url}`)
+// Same ApolloServer initialization as before, plus the drain plugin
+// for our httpServer.
+const server = new ApolloServer<MyContext>({
+  typeDefs,
+  resolvers,
+  plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
+});
+// Ensure we wait for our server to start
+await server.start();
+
+// Redirect to api graphql by default
+app.get('/', function (_, res) {
+  res.redirect('/api/graphql');
+});
+
+// Set up our Express middleware to handle CORS, body parsing,
+// and our expressMiddleware function.
+app.use(
+  '/api/graphql',
+  cors<cors.CorsRequest>(),
+  bodyParser.json(),
+  // expressMiddleware accepts the same arguments:
+  // an Apollo Server instance and optional configuration options
+  expressMiddleware(server, {
+    context: async ({ req }) => ({ token: req.headers.token }),
+  }),
+);
+
+// Modified server startup
+await new Promise<void>((resolve) => httpServer.listen({ port: 4000 }, resolve));
+console.log(`🚀 Server ready at http://localhost:4000/`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import cors from 'cors';
 import bodyParser from 'body-parser';
 import { resolvers } from "./resolvers.js"
 import { typeDefs } from "./schema.js"
+import { enlistedFilename, officerFilename } from "./constants.js";
+import { getEnlistedWorksheet, getOfficerWorksheet } from './helpers.js';
 
 interface MyContext {
   token?: string;
@@ -46,6 +48,45 @@ app.use(
     context: async ({ req }) => ({ token: req.headers.token }),
   }),
 );
+
+// health check sysinfo
+const __BUILD_ID__ = process.env.BUILD_ID
+const __NODE_ENV__ = process.env.NODE_ENV
+const __VERSION__ = process.env.VERSION
+
+app.get('/api/sysinfo', async function (_, res) {
+  try {
+    // determine if we are using local file system or s3
+    const isUsingS3 = process.env.S3_BUCKET_NAME && process.env.S3_BUCKET_NAME !== "test_bucket"
+    // grab the last modified times
+    const { lastModifiedAt: officerLastUpdated } = await getOfficerWorksheet()
+    const { lastModifiedAt: enlistedLastUpdated } = await getEnlistedWorksheet()
+
+    res.status(200).json({
+      version: __VERSION__,
+      buildId: __BUILD_ID__,
+      nodeEnv: __NODE_ENV__,
+      isUsingS3,
+      enlisted: {
+        filename: enlistedFilename,
+        lastModifiedAt: enlistedLastUpdated,
+      },
+      officer: {
+        filename: officerFilename,
+        lastModifiedAt: officerLastUpdated,
+      },
+    })
+  } catch (e) {
+    console.error(e)
+    // still output json for status in event of a failure
+    res.status(500).send({
+      version: __VERSION__,
+      buildId: __BUILD_ID__,
+      nodeEnv: __NODE_ENV__,
+      error: 'unable to access spreadsheets'
+    })
+  }
+});
 
 // Modified server startup
 await new Promise<void>((resolve) => httpServer.listen({ port: 4000 }, resolve));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,6 +1084,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cors@2.8.14":
+  version "2.8.14"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.14.tgz#94eeb1c95eda6a8ab54870a3bf88854512f43a92"
+  integrity sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/express-serve-static-core@^4.17.30", "@types/express-serve-static-core@^4.17.33":
   version "4.17.35"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz#c95dd4424f0d32e525d23812aa8ab8e4d3906c4f"
@@ -1323,7 +1330,7 @@ body-parser@1.20.1:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-body-parser@^1.20.0:
+body-parser@1.20.2, body-parser@^1.20.0:
   version "1.20.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.2.tgz#6feb0e21c4724d06de7ff38da36dad4f57a747fd"
   integrity sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==
@@ -1519,7 +1526,7 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cors@^2.8.5:
+cors@2.8.5, cors@^2.8.5:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
   integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
@@ -1645,7 +1652,7 @@ exceljs@4.3.0:
     unzipper "^0.10.11"
     uuid "^8.3.0"
 
-express@^4.17.1:
+express@4.18.2, express@^4.17.1:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
   integrity sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==


### PR DESCRIPTION
# SC-2353

## Proposed changes

Our deploy pipeline requires having an end point for determining health of the app. This PR adds a `/api/sysinfo` endpoint similar to our other applications to provide basic details of what version is deployed and confirm that the application is running.

## Reviewer notes

Anything else that should or shouldn't be in this? If an error occurs when checking for the spreadsheets the app returns a 500 code but still produces a json message with the version number. If you want to test the s3 setup as noted in https://github.com/USSF-ORBIT/ussf-portal/pull/312 . If you put in a wrong key it will error out and you can see what the error check looks like.

## Setup

```sh
yarn dev
curl http://localhost:4000/api/sysinfo
```

Also check that the endpoint still works as before http://localhost:4000