### PR TITLE
feat: Add getGuardianDirectory

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,7 @@ export const enlistedUserColumns = {
   Country: 23,
   BASE_LOC: 24,
   Org_type: 25,
+  org_kind: 26,
   EOPDate: 30,
   Last_Name: 32,
   First_name: 33,
@@ -31,6 +32,7 @@ export const officerUserColumns = {
   Country: 25,
   BASE_LOC: 26,
   org_kind: 27,
+  Org_type: 28,
   EOPDate: 31,
   Last_Name: 34,
   First_name: 35,
@@ -42,120 +44,120 @@ export const enlistedFilename = "enlisted_personnel_data.xlsx";
 
 export const enlistedRanks = [
   {
-    Title: 'Specialist One',
-    Abbreviation: 'Spc1',
-    Grade: 'E-1',
-    GradeId: '1'
+    Title: "Specialist One",
+    Abbreviation: "Spc1",
+    Grade: "E-1",
+    GradeId: "1",
   },
   {
-    Title: 'Specialist Two',
-    Abbreviation: 'Spc2',
-    Grade: 'E-2',
-    GradeId: '2'
+    Title: "Specialist Two",
+    Abbreviation: "Spc2",
+    Grade: "E-2",
+    GradeId: "2",
   },
   {
-    Title: 'Specialist Three',
-    Abbreviation: 'Spc3',
-    Grade: 'E-3',
-    GradeId: '3'
+    Title: "Specialist Three",
+    Abbreviation: "Spc3",
+    Grade: "E-3",
+    GradeId: "3",
   },
   {
-    Title: 'Specialist Four',
-    Abbreviation: 'Spc4',
-    Grade: 'E-4',
-    GradeId: '4'
+    Title: "Specialist Four",
+    Abbreviation: "Spc4",
+    Grade: "E-4",
+    GradeId: "4",
   },
   {
-    Title: 'Sergeant',
-    Abbreviation: 'Sgt',
-    Grade: 'E-5',
-    GradeId: '5'
+    Title: "Sergeant",
+    Abbreviation: "Sgt",
+    Grade: "E-5",
+    GradeId: "5",
   },
   {
-    Title: 'Technical Sergeant',
-    Abbreviation: 'TSgt',
-    Grade: 'E-6',
-    GradeId: '6'
+    Title: "Technical Sergeant",
+    Abbreviation: "TSgt",
+    Grade: "E-6",
+    GradeId: "6",
   },
   {
-    Title: 'Master Sergeant',
-    Abbreviation: 'MSgt',
-    Grade: 'E-7',
-    GradeId: '7'
+    Title: "Master Sergeant",
+    Abbreviation: "MSgt",
+    Grade: "E-7",
+    GradeId: "7",
   },
   {
-    Title: 'Senior Master Sergeant',
-    Abbreviation: 'SMSgt',
-    Grade: 'E-8',
-    GradeId: '8'
+    Title: "Senior Master Sergeant",
+    Abbreviation: "SMSgt",
+    Grade: "E-8",
+    GradeId: "8",
   },
   {
-    Title: 'Chief Master Sergeant',
-    Abbreviation: 'CMSgt',
-    Grade: 'E-9',
-    GradeId: '9'
+    Title: "Chief Master Sergeant",
+    Abbreviation: "CMSgt",
+    Grade: "E-9",
+    GradeId: "9",
   },
-]
+];
 
 export const officerRanks = [
   {
-    Title: 'Second Lieutenant',
-    Abbreviation: '2nd Lt',
-    Grade: 'O-1',
-    GradeId: '1'
+    Title: "Second Lieutenant",
+    Abbreviation: "2nd Lt",
+    Grade: "O-1",
+    GradeId: "1",
   },
   {
-    Title: 'Fisrt Lieutenant',
-    Abbreviation: '1st Lt',
-    Grade: 'O-2',
-    GradeId: '2'
+    Title: "Fisrt Lieutenant",
+    Abbreviation: "1st Lt",
+    Grade: "O-2",
+    GradeId: "2",
   },
   {
-    Title: 'Captain',
-    Abbreviation: 'Capt',
-    Grade: 'O-3',
-    GradeId: '3'
+    Title: "Captain",
+    Abbreviation: "Capt",
+    Grade: "O-3",
+    GradeId: "3",
   },
   {
-    Title: 'Major',
-    Abbreviation: 'Maj',
-    Grade: 'O-4',
-    GradeId: '4'
+    Title: "Major",
+    Abbreviation: "Maj",
+    Grade: "O-4",
+    GradeId: "4",
   },
   {
-    Title: 'Lieutenant Colonel',
-    Abbreviation: 'LtCol',
-    Grade: 'O-5',
-    GradeId: '5'
+    Title: "Lieutenant Colonel",
+    Abbreviation: "LtCol",
+    Grade: "O-5",
+    GradeId: "5",
   },
   {
-    Title: 'Colonel',
-    Abbreviation: 'Col',
-    Grade: 'O-6',
-    GradeId: '6'
+    Title: "Colonel",
+    Abbreviation: "Col",
+    Grade: "O-6",
+    GradeId: "6",
   },
   {
-    Title: 'Brigadier General',
-    Abbreviation: 'BGen',
-    Grade: 'O-7',
-    GradeId: '7'
+    Title: "Brigadier General",
+    Abbreviation: "BGen",
+    Grade: "O-7",
+    GradeId: "7",
   },
   {
-    Title: 'Major General',
-    Abbreviation: 'MGen',
-    Grade: 'O-8',
-    GradeId: '8'
+    Title: "Major General",
+    Abbreviation: "MGen",
+    Grade: "O-8",
+    GradeId: "8",
   },
   {
-    Title: 'Lieutenant General',
-    Abbreviation: 'LtGen',
-    Grade: 'O-9',
-    GradeId: '9'
+    Title: "Lieutenant General",
+    Abbreviation: "LtGen",
+    Grade: "O-9",
+    GradeId: "9",
   },
   {
-    Title: 'General',
-    Abbreviation: 'Gen',
-    Grade: 'O-10',
-    GradeId: '10'
+    Title: "General",
+    Abbreviation: "Gen",
+    Grade: "O-10",
+    GradeId: "10",
   },
-]
+];

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -233,7 +233,7 @@ export const resolvers = {
       for (let i = 2; i < enlistedWorksheetValues.length; i++) {
         const enlistedUser = enlistedWorksheet.getRow(i);
         enlistedGuardianDirectoryUsers.push({
-          DOD_ID: enlistedUser.getCell(officerUserColumns.DOD_ID).value,
+          DOD_ID: enlistedUser.getCell(enlistedUserColumns.DOD_ID).value,
           First_name: enlistedUser.getCell(enlistedUserColumns.First_name)
             .value,
           Middle_Name: enlistedUser.getCell(enlistedUserColumns.Middle_Name)

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,5 +1,10 @@
 import { enlistedUserColumns, officerUserColumns } from "./constants.js";
-import { getEnlistedRankFromGrade, getEnlistedWorksheet, getOfficerRankFromGrade, getOfficerWorksheet } from "./helpers.js";
+import {
+  getEnlistedRankFromGrade,
+  getEnlistedWorksheet,
+  getOfficerRankFromGrade,
+  getOfficerWorksheet,
+} from "./helpers.js";
 
 export const resolvers = {
   Query: {
@@ -20,7 +25,7 @@ export const resolvers = {
       const foundUser = worksheet.getRow(foundUserRow);
 
       if (foundUserRow !== -1 && foundUser) {
-        const grade = foundUser.getCell(enlistedUserColumns.Grade).value
+        const grade = foundUser.getCell(enlistedUserColumns.Grade).value;
         return {
           Rank: getEnlistedRankFromGrade(grade),
           Grade: grade,
@@ -62,7 +67,7 @@ export const resolvers = {
       const foundUser = worksheet.getRow(foundUserRow);
 
       if (foundUserRow !== -1 && foundUser) {
-        const grade = foundUser.getCell(officerUserColumns.Grade).value
+        const grade = foundUser.getCell(officerUserColumns.Grade).value;
         return {
           Rank: getOfficerRankFromGrade(grade),
           Grade: grade,
@@ -106,7 +111,7 @@ export const resolvers = {
       const foundOfficerUser = officerWorksheet.getRow(foundOfficerUserRow);
 
       if (foundOfficerUserRow !== -1 && foundOfficerUser) {
-        const grade = foundOfficerUser.getCell(officerUserColumns.Grade).value
+        const grade = foundOfficerUser.getCell(officerUserColumns.Grade).value;
         return {
           Rank: getOfficerRankFromGrade(grade),
           Grade: grade,
@@ -151,7 +156,9 @@ export const resolvers = {
       const foundEnlistedUser = enlistedWorksheet.getRow(foundEnlistedUserRow);
 
       if (foundEnlistedUserRow !== -1 && foundEnlistedUser) {
-        const grade = foundEnlistedUser.getCell(enlistedUserColumns.Grade).value
+        const grade = foundEnlistedUser.getCell(
+          enlistedUserColumns.Grade
+        ).value;
         return {
           Rank: getEnlistedRankFromGrade(grade),
           Grade: grade,
@@ -185,6 +192,67 @@ export const resolvers = {
 
       // If not found in either list, return null
       return null;
+    },
+    getGuardianDirectory: async () => {
+      const { worksheet: officerWorksheet } = await getOfficerWorksheet();
+      const { worksheet: enlistedWorksheet } = await getEnlistedWorksheet();
+
+      const officerWorksheetValues = officerWorksheet.getColumn(
+        officerUserColumns.DOD_ID
+      ).values;
+
+      const enlistedWorksheetValues = enlistedWorksheet.getColumn(
+        enlistedUserColumns.DOD_ID
+      ).values;
+
+      const officerGuardianDirectoryUsers = [];
+      const enlistedGuardianDirectoryUsers = [];
+
+      // Initializing at 2 to skip the header row
+      for (let i = 2; i < officerWorksheetValues.length; i++) {
+        const officerUser = officerWorksheet.getRow(i);
+        officerGuardianDirectoryUsers.push({
+          First_name: officerUser.getCell(officerUserColumns.First_name).value,
+          Middle_Name: officerUser.getCell(officerUserColumns.Middle_Name)
+            .value,
+          Last_Name: officerUser.getCell(officerUserColumns.Last_Name).value,
+          Email: officerUser.getCell(officerUserColumns.ATP31).value,
+          Rank: getOfficerRankFromGrade(
+            officerUser.getCell(officerUserColumns.Grade).value
+          ),
+          Duty: officerUser.getCell(officerUserColumns.DUTYTITLE).value,
+          BaseLoc: officerUser.getCell(officerUserColumns.BASE_LOC).value,
+          MajCom: officerUser.getCell(officerUserColumns.MAJCOM).value,
+          OrgType: officerUser.getCell(officerUserColumns.Org_type).value,
+          OrgKind: officerUser.getCell(officerUserColumns.org_kind).value,
+        });
+      }
+
+      // Initializing at 2 to skip the header row
+      for (let i = 2; i < enlistedWorksheetValues.length; i++) {
+        const enlistedUser = enlistedWorksheet.getRow(i);
+        enlistedGuardianDirectoryUsers.push({
+          First_name: enlistedUser.getCell(enlistedUserColumns.First_name)
+            .value,
+          Middle_Name: enlistedUser.getCell(enlistedUserColumns.Middle_Name)
+            .value,
+          Last_Name: enlistedUser.getCell(enlistedUserColumns.Last_Name).value,
+          Email: enlistedUser.getCell(enlistedUserColumns.ATP31).value,
+          Rank: getEnlistedRankFromGrade(
+            enlistedUser.getCell(enlistedUserColumns.Grade).value
+          ),
+          Duty: enlistedUser.getCell(enlistedUserColumns.DUTYTITLE).value,
+          BaseLoc: enlistedUser.getCell(enlistedUserColumns.BASE_LOC).value,
+          MajCom: enlistedUser.getCell(enlistedUserColumns.MAJCOM).value,
+          OrgType: enlistedUser.getCell(enlistedUserColumns.Org_type).value,
+          OrgKind: enlistedUser.getCell(enlistedUserColumns.org_kind).value,
+        });
+      }
+
+      return [
+        ...officerGuardianDirectoryUsers,
+        ...enlistedGuardianDirectoryUsers,
+      ];
     },
   },
 };

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -249,10 +249,20 @@ export const resolvers = {
         });
       }
 
-      return [
+      const sortedArray = [
         ...officerGuardianDirectoryUsers,
         ...enlistedGuardianDirectoryUsers,
-      ];
+      ].sort((a, b) => {
+        if (a.Last_Name! < b.Last_Name!) {
+          return -1;
+        }
+        if (a.Last_Name! > b.Last_Name!) {
+          return 1;
+        }
+        return 0;
+      });
+
+      return sortedArray;
     },
   },
 };

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -212,6 +212,7 @@ export const resolvers = {
       for (let i = 2; i < officerWorksheetValues.length; i++) {
         const officerUser = officerWorksheet.getRow(i);
         officerGuardianDirectoryUsers.push({
+          DOD_ID: officerUser.getCell(officerUserColumns.DOD_ID).value,
           First_name: officerUser.getCell(officerUserColumns.First_name).value,
           Middle_Name: officerUser.getCell(officerUserColumns.Middle_Name)
             .value,
@@ -232,6 +233,7 @@ export const resolvers = {
       for (let i = 2; i < enlistedWorksheetValues.length; i++) {
         const enlistedUser = enlistedWorksheet.getRow(i);
         enlistedGuardianDirectoryUsers.push({
+          DOD_ID: enlistedUser.getCell(officerUserColumns.DOD_ID).value,
           First_name: enlistedUser.getCell(enlistedUserColumns.First_name)
             .value,
           Middle_Name: enlistedUser.getCell(enlistedUserColumns.Middle_Name)

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2,9 +2,9 @@ import { gql } from "graphql-tag";
 
 export const typeDefs = gql`
   type Rank {
-    Title: String,
-    Abbreviation: String,
-    Grade: String,
+    Title: String
+    Abbreviation: String
+    Grade: String
     GradeId: String
   }
 
@@ -34,6 +34,19 @@ export const typeDefs = gql`
     lastModifiedAt: String
   }
 
+  type GuardianDirectoryUser {
+    First_name: String
+    Middle_Name: String
+    Last_Name: String
+    Email: String
+    Rank: Rank
+    Duty: String
+    BaseLoc: String
+    MajCom: String
+    OrgType: String
+    OrgKind: String
+  }
+
   type Query {
     getEnlistedUser(id: String!): User
   }
@@ -44,5 +57,9 @@ export const typeDefs = gql`
 
   type Query {
     getUser(id: String!): User
+  }
+
+  type Query {
+    getGuardianDirectory: [GuardianDirectoryUser]
   }
 `;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -35,6 +35,7 @@ export const typeDefs = gql`
   }
 
   type GuardianDirectoryUser {
+    DOD_ID: String
     First_name: String
     Middle_Name: String
     Last_Name: String
@@ -49,17 +50,8 @@ export const typeDefs = gql`
 
   type Query {
     getEnlistedUser(id: String!): User
-  }
-
-  type Query {
     getOfficerUser(id: String!): User
-  }
-
-  type Query {
     getUser(id: String!): User
-  }
-
-  type Query {
     getGuardianDirectory: [GuardianDirectoryUser]
   }
 `;


### PR DESCRIPTION
# SC-1996

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
Adds a resolver for getting all users from both the Enlisted spreadsheet, and the Officer spreadsheet.
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
Once you have the API running locally, test the `getGuardianDirectory` query and make sure that all rows from the spreadsheet are returned in alphabetical order.
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

---

## Setup
Run `yarn dev` and navigate to `localhost:4000`
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

---
