### PR TITLE
feat: Normalize data between resolvers

### DIFF
--- a/.github/workflows/build-docker-cache-artifacts.yml
+++ b/.github/workflows/build-docker-cache-artifacts.yml
@@ -1,0 +1,54 @@
+name: Docker Build Cache Save Artifact
+
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md**'
+    branches: [ main ]
+
+jobs:
+  build-and-push-dev-aws:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - name: Get tag
+        run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+
+      - name: Docker setup buildx
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
+        id: buildx
+        with:
+          install: true
+
+      - name: Build personnel-api
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4
+        with:
+          context: .
+          tags: personnel-api:e2e
+          cache-to: type=local,mode=max,dest=/tmp/personnel-api,tag=e2e
+
+      - name: Upload personnel-api cache dir
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+        with:
+          name: personnel-api
+          path: /tmp/personnel-api
+
+      - name: Upload personnel-api manifest
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+        with:
+          name: personnel-api-index
+          path: /tmp/personnel-api/index.json
+
+      - name: Get docker image digest from manifest
+        id: manifest
+        run: |
+          digest=$(cat /tmp/personnel-api/index.json | jq -r '.manifests[0].digest')
+          echo "docker_tag=${digest##sha256:}" >> $GITHUB_OUTPUT
+
+      - name: Save docker cache to GHA cache using image digest as key
+        uses: actions/cache/save@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3
+        with:
+          path: /tmp/personnel-api
+          key: ${{ runner.os }}-docker-personnel-api-${{ steps.manifest.outputs.docker_tag }}

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -1,0 +1,12 @@
+name: E2E tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  run-e2e-tests:
+    uses: USSF-ORBIT/ussf-portal/.github/workflows/reusable-run-e2e-tests.yml@main
+    secrets: inherit

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,7 @@ export const enlistedUserColumns = {
   Country: 23,
   BASE_LOC: 24,
   Org_type: 25,
+  org_kind: 26,
   EOPDate: 30,
   Last_Name: 32,
   First_name: 33,
@@ -31,6 +32,7 @@ export const officerUserColumns = {
   Country: 25,
   BASE_LOC: 26,
   org_kind: 27,
+  Org_type: 28,
   EOPDate: 31,
   Last_Name: 34,
   First_name: 35,
@@ -42,120 +44,120 @@ export const enlistedFilename = "enlisted_personnel_data.xlsx";
 
 export const enlistedRanks = [
   {
-    Title: 'Specialist One',
-    Abbreviation: 'Spc1',
-    Grade: 'E-1',
-    GradeId: '1'
+    Title: "Specialist One",
+    Abbreviation: "Spc1",
+    Grade: "E-1",
+    GradeId: "1",
   },
   {
-    Title: 'Specialist Two',
-    Abbreviation: 'Spc2',
-    Grade: 'E-2',
-    GradeId: '2'
+    Title: "Specialist Two",
+    Abbreviation: "Spc2",
+    Grade: "E-2",
+    GradeId: "2",
   },
   {
-    Title: 'Specialist Three',
-    Abbreviation: 'Spc3',
-    Grade: 'E-3',
-    GradeId: '3'
+    Title: "Specialist Three",
+    Abbreviation: "Spc3",
+    Grade: "E-3",
+    GradeId: "3",
   },
   {
-    Title: 'Specialist Four',
-    Abbreviation: 'Spc4',
-    Grade: 'E-4',
-    GradeId: '4'
+    Title: "Specialist Four",
+    Abbreviation: "Spc4",
+    Grade: "E-4",
+    GradeId: "4",
   },
   {
-    Title: 'Sergeant',
-    Abbreviation: 'Sgt',
-    Grade: 'E-5',
-    GradeId: '5'
+    Title: "Sergeant",
+    Abbreviation: "Sgt",
+    Grade: "E-5",
+    GradeId: "5",
   },
   {
-    Title: 'Technical Sergeant',
-    Abbreviation: 'TSgt',
-    Grade: 'E-6',
-    GradeId: '6'
+    Title: "Technical Sergeant",
+    Abbreviation: "TSgt",
+    Grade: "E-6",
+    GradeId: "6",
   },
   {
-    Title: 'Master Sergeant',
-    Abbreviation: 'MSgt',
-    Grade: 'E-7',
-    GradeId: '7'
+    Title: "Master Sergeant",
+    Abbreviation: "MSgt",
+    Grade: "E-7",
+    GradeId: "7",
   },
   {
-    Title: 'Senior Master Sergeant',
-    Abbreviation: 'SMSgt',
-    Grade: 'E-8',
-    GradeId: '8'
+    Title: "Senior Master Sergeant",
+    Abbreviation: "SMSgt",
+    Grade: "E-8",
+    GradeId: "8",
   },
   {
-    Title: 'Chief Master Sergeant',
-    Abbreviation: 'CMSgt',
-    Grade: 'E-9',
-    GradeId: '9'
+    Title: "Chief Master Sergeant",
+    Abbreviation: "CMSgt",
+    Grade: "E-9",
+    GradeId: "9",
   },
-]
+];
 
 export const officerRanks = [
   {
-    Title: 'Second Lieutenant',
-    Abbreviation: '2nd Lt',
-    Grade: 'O-1',
-    GradeId: '1'
+    Title: "Second Lieutenant",
+    Abbreviation: "2nd Lt",
+    Grade: "O-1",
+    GradeId: "1",
   },
   {
-    Title: 'Fisrt Lieutenant',
-    Abbreviation: '1st Lt',
-    Grade: 'O-2',
-    GradeId: '2'
+    Title: "Fisrt Lieutenant",
+    Abbreviation: "1st Lt",
+    Grade: "O-2",
+    GradeId: "2",
   },
   {
-    Title: 'Captain',
-    Abbreviation: 'Capt',
-    Grade: 'O-3',
-    GradeId: '3'
+    Title: "Captain",
+    Abbreviation: "Capt",
+    Grade: "O-3",
+    GradeId: "3",
   },
   {
-    Title: 'Major',
-    Abbreviation: 'Maj',
-    Grade: 'O-4',
-    GradeId: '4'
+    Title: "Major",
+    Abbreviation: "Maj",
+    Grade: "O-4",
+    GradeId: "4",
   },
   {
-    Title: 'Lieutenant Colonel',
-    Abbreviation: 'LtCol',
-    Grade: 'O-5',
-    GradeId: '5'
+    Title: "Lieutenant Colonel",
+    Abbreviation: "LtCol",
+    Grade: "O-5",
+    GradeId: "5",
   },
   {
-    Title: 'Colonel',
-    Abbreviation: 'Col',
-    Grade: 'O-6',
-    GradeId: '6'
+    Title: "Colonel",
+    Abbreviation: "Col",
+    Grade: "O-6",
+    GradeId: "6",
   },
   {
-    Title: 'Brigadier General',
-    Abbreviation: 'BGen',
-    Grade: 'O-7',
-    GradeId: '7'
+    Title: "Brigadier General",
+    Abbreviation: "BGen",
+    Grade: "O-7",
+    GradeId: "7",
   },
   {
-    Title: 'Major General',
-    Abbreviation: 'MGen',
-    Grade: 'O-8',
-    GradeId: '8'
+    Title: "Major General",
+    Abbreviation: "MGen",
+    Grade: "O-8",
+    GradeId: "8",
   },
   {
-    Title: 'Lieutenant General',
-    Abbreviation: 'LtGen',
-    Grade: 'O-9',
-    GradeId: '9'
+    Title: "Lieutenant General",
+    Abbreviation: "LtGen",
+    Grade: "O-9",
+    GradeId: "9",
   },
   {
-    Title: 'General',
-    Abbreviation: 'Gen',
-    Grade: 'O-10',
-    GradeId: '10'
+    Title: "General",
+    Abbreviation: "Gen",
+    Grade: "O-10",
+    GradeId: "10",
   },
-]
+];

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -70,3 +70,32 @@ export const getOfficerRankFromGrade = async (grade: CellValue) => {
   })
   return rank
 }
+
+/** Convert a string to title case */
+export const titleCase = (value: CellValue) => {
+  const str = value?.toString()
+  if (str) {
+    return titleCaseStr(str)
+  }
+  return ''
+}
+
+export const titleCaseMajCom = (value: CellValue) => {
+  const str = value?.toString()
+  if (str) {
+    const split = str.split('(')
+    const majcom = split[0]
+    return titleCaseStr(majcom) + `(${split[1]}`
+  }
+  return ''
+}
+
+export const titleCaseStr = (str: string) => {
+  return str
+    .toLowerCase()
+    .split(' ')
+    .map(function (word) {
+      return word.charAt(0).toUpperCase() + word.slice(1)
+    })
+    .join(' ')
+}

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -29,22 +29,22 @@ export const resolvers = {
         return {
           Rank: getEnlistedRankFromGrade(grade),
           Grade: grade,
-          DUTYTITLE: foundUser.getCell(enlistedUserColumns.DUTYTITLE).value,
+          DutyTitle: foundUser.getCell(enlistedUserColumns.DUTYTITLE).value,
           AMU: foundUser.getCell(enlistedUserColumns.AMU).value,
           DOD_ID: foundUser.getCell(enlistedUserColumns.DOD_ID).value,
           ATP31: foundUser.getCell(enlistedUserColumns.ATP31).value,
           AFC291_01: foundUser.getCell(enlistedUserColumns.AFC291_01).value,
           AMF: foundUser.getCell(enlistedUserColumns.AMF).value,
           MPF: foundUser.getCell(enlistedUserColumns.MPF).value,
-          MAJCOM: foundUser.getCell(enlistedUserColumns.MAJCOM).value,
+          MajCom: foundUser.getCell(enlistedUserColumns.MAJCOM).value,
           Country: foundUser.getCell(enlistedUserColumns.Country).value,
-          BASE_LOC: foundUser.getCell(enlistedUserColumns.BASE_LOC).value,
-          Org_type: foundUser.getCell(enlistedUserColumns.Org_type).value,
+          BaseLoc: foundUser.getCell(enlistedUserColumns.BASE_LOC).value,
+          OrgType: foundUser.getCell(enlistedUserColumns.Org_type).value,
           EOPDate: foundUser.getCell(enlistedUserColumns.EOPDate).value,
-          Last_Name: foundUser.getCell(enlistedUserColumns.Last_Name).value,
-          First_name: foundUser.getCell(enlistedUserColumns.First_name).value,
-          Middle_Name: foundUser.getCell(enlistedUserColumns.Middle_Name).value,
-          userType: "Enlisted",
+          LastName: foundUser.getCell(enlistedUserColumns.Last_Name).value,
+          FirstName: foundUser.getCell(enlistedUserColumns.First_name).value,
+          MiddleName: foundUser.getCell(enlistedUserColumns.Middle_Name).value,
+          UserType: "Enlisted",
           lastModifiedAt: lastMod.toString(),
         };
       }
@@ -76,18 +76,18 @@ export const resolvers = {
           ATP31: foundUser.getCell(officerUserColumns.ATP31).value,
           CAS3: foundUser.getCell(officerUserColumns.CAS3).value,
           AMF: foundUser.getCell(officerUserColumns.AMF).value,
-          DUTYTITLE: foundUser.getCell(officerUserColumns.DUTYTITLE).value,
+          DutyTitle: foundUser.getCell(officerUserColumns.DUTYTITLE).value,
           MPF: foundUser.getCell(officerUserColumns.MPF).value,
           CMD: foundUser.getCell(officerUserColumns.CMD).value,
-          MAJCOM: foundUser.getCell(officerUserColumns.MAJCOM).value,
+          MajCom: foundUser.getCell(officerUserColumns.MAJCOM).value,
           Country: foundUser.getCell(officerUserColumns.Country).value,
-          BASE_LOC: foundUser.getCell(officerUserColumns.BASE_LOC).value,
-          org_kind: foundUser.getCell(officerUserColumns.org_kind).value,
+          BaseLoc: foundUser.getCell(officerUserColumns.BASE_LOC).value,
+          OrgKind: foundUser.getCell(officerUserColumns.org_kind).value,
           EOPDate: foundUser.getCell(officerUserColumns.EOPDate).value,
-          Last_Name: foundUser.getCell(officerUserColumns.Last_Name).value,
-          First_name: foundUser.getCell(officerUserColumns.First_name).value,
-          Middle_Name: foundUser.getCell(officerUserColumns.Middle_Name).value,
-          userType: "Officer",
+          LastName: foundUser.getCell(officerUserColumns.Last_Name).value,
+          FirstName: foundUser.getCell(officerUserColumns.First_name).value,
+          MiddleName: foundUser.getCell(officerUserColumns.Middle_Name).value,
+          UserType: "Officer",
           lastModifiedAt: lastMod.toString(),
         };
       }
@@ -120,20 +120,20 @@ export const resolvers = {
           ATP31: foundOfficerUser.getCell(officerUserColumns.ATP31).value,
           CAS3: foundOfficerUser.getCell(officerUserColumns.CAS3).value,
           AMF: foundOfficerUser.getCell(officerUserColumns.AMF).value,
-          DUTYTITLE: foundOfficerUser.getCell(officerUserColumns.DUTYTITLE)
+          DutyTitle: foundOfficerUser.getCell(officerUserColumns.DUTYTITLE)
             .value,
           MPF: foundOfficerUser.getCell(officerUserColumns.MPF).value,
           CMD: foundOfficerUser.getCell(officerUserColumns.CMD).value,
-          MAJCOM: foundOfficerUser.getCell(officerUserColumns.MAJCOM).value,
+          MajCom: foundOfficerUser.getCell(officerUserColumns.MAJCOM).value,
           Country: foundOfficerUser.getCell(officerUserColumns.Country).value,
-          BASE_LOC: foundOfficerUser.getCell(officerUserColumns.BASE_LOC).value,
-          org_kind: foundOfficerUser.getCell(officerUserColumns.org_kind).value,
+          BaseLoc: foundOfficerUser.getCell(officerUserColumns.BASE_LOC).value,
+          OrgKind: foundOfficerUser.getCell(officerUserColumns.org_kind).value,
           EOPDate: foundOfficerUser.getCell(officerUserColumns.EOPDate).value,
-          Last_Name: foundOfficerUser.getCell(officerUserColumns.Last_Name)
+          LastName: foundOfficerUser.getCell(officerUserColumns.Last_Name)
             .value,
-          First_name: foundOfficerUser.getCell(officerUserColumns.First_name)
+          FirstName: foundOfficerUser.getCell(officerUserColumns.First_name)
             .value,
-          Middle_Name: foundOfficerUser.getCell(officerUserColumns.Middle_Name)
+          MiddleName: foundOfficerUser.getCell(officerUserColumns.Middle_Name)
             .value,
           userType: "Officer",
           lastModifiedAt: officerLastMod.toString(),
@@ -213,15 +213,15 @@ export const resolvers = {
         const officerUser = officerWorksheet.getRow(i);
         officerGuardianDirectoryUsers.push({
           DOD_ID: officerUser.getCell(officerUserColumns.DOD_ID).value,
-          First_name: officerUser.getCell(officerUserColumns.First_name).value,
-          Middle_Name: officerUser.getCell(officerUserColumns.Middle_Name)
+          FirstName: officerUser.getCell(officerUserColumns.First_name).value,
+          MiddleName: officerUser.getCell(officerUserColumns.Middle_Name)
             .value,
-          Last_Name: officerUser.getCell(officerUserColumns.Last_Name).value,
+          LastName: officerUser.getCell(officerUserColumns.Last_Name).value,
           Email: officerUser.getCell(officerUserColumns.ATP31).value,
           Rank: getOfficerRankFromGrade(
             officerUser.getCell(officerUserColumns.Grade).value
           ),
-          Duty: officerUser.getCell(officerUserColumns.DUTYTITLE).value,
+          DutyTitle: officerUser.getCell(officerUserColumns.DUTYTITLE).value,
           BaseLoc: officerUser.getCell(officerUserColumns.BASE_LOC).value,
           MajCom: officerUser.getCell(officerUserColumns.MAJCOM).value,
           OrgType: officerUser.getCell(officerUserColumns.Org_type).value,
@@ -234,16 +234,16 @@ export const resolvers = {
         const enlistedUser = enlistedWorksheet.getRow(i);
         enlistedGuardianDirectoryUsers.push({
           DOD_ID: enlistedUser.getCell(enlistedUserColumns.DOD_ID).value,
-          First_name: enlistedUser.getCell(enlistedUserColumns.First_name)
+          FirstName: enlistedUser.getCell(enlistedUserColumns.First_name)
             .value,
-          Middle_Name: enlistedUser.getCell(enlistedUserColumns.Middle_Name)
+          MiddleName: enlistedUser.getCell(enlistedUserColumns.Middle_Name)
             .value,
-          Last_Name: enlistedUser.getCell(enlistedUserColumns.Last_Name).value,
+          LastName: enlistedUser.getCell(enlistedUserColumns.Last_Name).value,
           Email: enlistedUser.getCell(enlistedUserColumns.ATP31).value,
           Rank: getEnlistedRankFromGrade(
             enlistedUser.getCell(enlistedUserColumns.Grade).value
           ),
-          Duty: enlistedUser.getCell(enlistedUserColumns.DUTYTITLE).value,
+          DutyTitle: enlistedUser.getCell(enlistedUserColumns.DUTYTITLE).value,
           BaseLoc: enlistedUser.getCell(enlistedUserColumns.BASE_LOC).value,
           MajCom: enlistedUser.getCell(enlistedUserColumns.MAJCOM).value,
           OrgType: enlistedUser.getCell(enlistedUserColumns.Org_type).value,
@@ -255,10 +255,10 @@ export const resolvers = {
         ...officerGuardianDirectoryUsers,
         ...enlistedGuardianDirectoryUsers,
       ].sort((a, b) => {
-        if (a.Last_Name! < b.Last_Name!) {
+        if (a.LastName! < b.LastName!) {
           return -1;
         }
-        if (a.Last_Name! > b.Last_Name!) {
+        if (a.LastName! > b.LastName!) {
           return 1;
         }
         return 0;

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -233,7 +233,7 @@ export const resolvers = {
       for (let i = 2; i < enlistedWorksheetValues.length; i++) {
         const enlistedUser = enlistedWorksheet.getRow(i);
         enlistedGuardianDirectoryUsers.push({
-          DOD_ID: enlistedUser.getCell(officerUserColumns.DOD_ID).value,
+          DOD_ID: enlistedUser.getCell(enlistedUserColumns.DOD_ID).value,
           First_name: enlistedUser.getCell(enlistedUserColumns.First_name)
             .value,
           Middle_Name: enlistedUser.getCell(enlistedUserColumns.Middle_Name)

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,5 +1,10 @@
 import { enlistedUserColumns, officerUserColumns } from "./constants.js";
-import { getEnlistedRankFromGrade, getEnlistedWorksheet, getOfficerRankFromGrade, getOfficerWorksheet } from "./helpers.js";
+import {
+  getEnlistedRankFromGrade,
+  getEnlistedWorksheet,
+  getOfficerRankFromGrade,
+  getOfficerWorksheet,
+} from "./helpers.js";
 
 export const resolvers = {
   Query: {
@@ -20,7 +25,7 @@ export const resolvers = {
       const foundUser = worksheet.getRow(foundUserRow);
 
       if (foundUserRow !== -1 && foundUser) {
-        const grade = foundUser.getCell(enlistedUserColumns.Grade).value
+        const grade = foundUser.getCell(enlistedUserColumns.Grade).value;
         return {
           Rank: getEnlistedRankFromGrade(grade),
           Grade: grade,
@@ -62,7 +67,7 @@ export const resolvers = {
       const foundUser = worksheet.getRow(foundUserRow);
 
       if (foundUserRow !== -1 && foundUser) {
-        const grade = foundUser.getCell(officerUserColumns.Grade).value
+        const grade = foundUser.getCell(officerUserColumns.Grade).value;
         return {
           Rank: getOfficerRankFromGrade(grade),
           Grade: grade,
@@ -106,7 +111,7 @@ export const resolvers = {
       const foundOfficerUser = officerWorksheet.getRow(foundOfficerUserRow);
 
       if (foundOfficerUserRow !== -1 && foundOfficerUser) {
-        const grade = foundOfficerUser.getCell(officerUserColumns.Grade).value
+        const grade = foundOfficerUser.getCell(officerUserColumns.Grade).value;
         return {
           Rank: getOfficerRankFromGrade(grade),
           Grade: grade,
@@ -151,7 +156,9 @@ export const resolvers = {
       const foundEnlistedUser = enlistedWorksheet.getRow(foundEnlistedUserRow);
 
       if (foundEnlistedUserRow !== -1 && foundEnlistedUser) {
-        const grade = foundEnlistedUser.getCell(enlistedUserColumns.Grade).value
+        const grade = foundEnlistedUser.getCell(
+          enlistedUserColumns.Grade
+        ).value;
         return {
           Rank: getEnlistedRankFromGrade(grade),
           Grade: grade,
@@ -185,6 +192,67 @@ export const resolvers = {
 
       // If not found in either list, return null
       return null;
+    },
+    getGuardianDirectory: async () => {
+      const { worksheet: officerWorksheet } = await getOfficerWorksheet();
+      const { worksheet: enlistedWorksheet } = await getEnlistedWorksheet();
+
+      const officerWorksheetValues = officerWorksheet.getColumn(
+        officerUserColumns.DOD_ID
+      ).values;
+
+      const enlistedWorksheetValues = enlistedWorksheet.getColumn(
+        enlistedUserColumns.DOD_ID
+      ).values;
+
+      const officerGuardianDirectoryUsers = [];
+      const enlistedGuardianDirectoryUsers = [];
+
+      // Initializing at 2 to skip the header row
+      for (let i = 2; i < officerWorksheetValues.length; i++) {
+        const officerUser = officerWorksheet.getRow(i);
+        officerGuardianDirectoryUsers.push({
+          First_name: officerUser.getCell(officerUserColumns.First_name).value,
+          Middle_Name: officerUser.getCell(officerUserColumns.Middle_Name)
+            .value,
+          Last_Name: officerUser.getCell(officerUserColumns.Last_Name).value,
+          Email: officerUser.getCell(officerUserColumns.ATP31).value,
+          Rank: getOfficerRankFromGrade(
+            officerUser.getCell(officerUserColumns.Grade).value
+          ),
+          Duty: officerUser.getCell(officerUserColumns.DUTYTITLE).value,
+          BaseLoc: officerUser.getCell(officerUserColumns.BASE_LOC).value,
+          MajCom: officerUser.getCell(officerUserColumns.MAJCOM).value,
+          OrgType: officerUser.getCell(officerUserColumns.Org_type).value,
+          OrgKind: officerUser.getCell(officerUserColumns.org_kind).value,
+        });
+      }
+
+      // Initializing at 2 to skip the header row
+      for (let i = 2; i < enlistedWorksheetValues.length; i++) {
+        const enlistedUser = enlistedWorksheet.getRow(i);
+        enlistedGuardianDirectoryUsers.push({
+          First_name: enlistedUser.getCell(enlistedUserColumns.First_name)
+            .value,
+          Middle_Name: enlistedUser.getCell(enlistedUserColumns.Middle_Name)
+            .value,
+          Last_Name: enlistedUser.getCell(enlistedUserColumns.Last_Name).value,
+          Email: enlistedUser.getCell(enlistedUserColumns.ATP31).value,
+          Rank: getEnlistedRankFromGrade(
+            enlistedUser.getCell(enlistedUserColumns.Grade).value
+          ),
+          Duty: enlistedUser.getCell(enlistedUserColumns.DUTYTITLE).value,
+          BaseLoc: enlistedUser.getCell(enlistedUserColumns.BASE_LOC).value,
+          MajCom: enlistedUser.getCell(enlistedUserColumns.MAJCOM).value,
+          OrgType: enlistedUser.getCell(enlistedUserColumns.Org_type).value,
+          OrgKind: enlistedUser.getCell(enlistedUserColumns.org_kind).value,
+        });
+      }
+
+      return [
+        ...officerGuardianDirectoryUsers,
+        ...enlistedGuardianDirectoryUsers,
+      ];
     },
   },
 };

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -135,7 +135,7 @@ export const resolvers = {
             .value,
           MiddleName: foundOfficerUser.getCell(officerUserColumns.Middle_Name)
             .value,
-          userType: "Officer",
+          UserType: "Officer",
           lastModifiedAt: officerLastMod.toString(),
         };
       }
@@ -162,7 +162,7 @@ export const resolvers = {
         return {
           Rank: getEnlistedRankFromGrade(grade),
           Grade: grade,
-          DUTYTITLE: foundEnlistedUser.getCell(enlistedUserColumns.DUTYTITLE)
+          DutyTitle: foundEnlistedUser.getCell(enlistedUserColumns.DUTYTITLE)
             .value,
           AMU: foundEnlistedUser.getCell(enlistedUserColumns.AMU).value,
           DOD_ID: foundEnlistedUser.getCell(enlistedUserColumns.DOD_ID).value,
@@ -171,21 +171,21 @@ export const resolvers = {
             .value,
           AMF: foundEnlistedUser.getCell(enlistedUserColumns.AMF).value,
           MPF: foundEnlistedUser.getCell(enlistedUserColumns.MPF).value,
-          MAJCOM: foundEnlistedUser.getCell(enlistedUserColumns.MAJCOM).value,
+          MajCom: foundEnlistedUser.getCell(enlistedUserColumns.MAJCOM).value,
           Country: foundEnlistedUser.getCell(enlistedUserColumns.Country).value,
-          BASE_LOC: foundEnlistedUser.getCell(enlistedUserColumns.BASE_LOC)
+          BaseLoc: foundEnlistedUser.getCell(enlistedUserColumns.BASE_LOC)
             .value,
-          Org_type: foundEnlistedUser.getCell(enlistedUserColumns.Org_type)
+          OrgType: foundEnlistedUser.getCell(enlistedUserColumns.Org_type)
             .value,
           EOPDate: foundEnlistedUser.getCell(enlistedUserColumns.EOPDate).value,
-          Last_Name: foundEnlistedUser.getCell(enlistedUserColumns.Last_Name)
+          LastName: foundEnlistedUser.getCell(enlistedUserColumns.Last_Name)
             .value,
-          First_name: foundEnlistedUser.getCell(enlistedUserColumns.First_name)
+          FirstName: foundEnlistedUser.getCell(enlistedUserColumns.First_name)
             .value,
-          Middle_Name: foundEnlistedUser.getCell(
+          MiddleName: foundEnlistedUser.getCell(
             enlistedUserColumns.Middle_Name
           ).value,
-          userType: "Enlisted",
+          UserType: "Enlisted",
           lastModifiedAt: enlistedLastMod.toString(),
         };
       }

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,10 +1,67 @@
+import { DateTime } from "luxon";
 import { enlistedUserColumns, officerUserColumns } from "./constants.js";
 import {
   getEnlistedRankFromGrade,
   getEnlistedWorksheet,
   getOfficerRankFromGrade,
   getOfficerWorksheet,
+  titleCase,
+  titleCaseMajCom,
 } from "./helpers.js";
+import { Row } from "exceljs";
+
+const createOfficerUser = (foundUser: Row, lastModifiedAt: DateTime) => {
+  const grade = foundUser.getCell(officerUserColumns.Grade).value
+  const email = foundUser.getCell(officerUserColumns.ATP31).value?.toString()
+  return {
+    Rank: getOfficerRankFromGrade(grade),
+    Grade: grade,
+    ANB2: foundUser.getCell(officerUserColumns.ANB2).value,
+    DOD_ID: foundUser.getCell(officerUserColumns.DOD_ID).value,
+    Email: email ? email.toLowerCase() : '',
+    CAS3: foundUser.getCell(officerUserColumns.CAS3).value,
+    AMF: foundUser.getCell(officerUserColumns.AMF).value,
+    DutyTitle: titleCase(foundUser.getCell(officerUserColumns.DUTYTITLE).value),
+    MPF: foundUser.getCell(officerUserColumns.MPF).value,
+    CMD: foundUser.getCell(officerUserColumns.CMD).value,
+    MajCom: titleCaseMajCom(foundUser.getCell(officerUserColumns.MAJCOM).value),
+    Country: foundUser.getCell(officerUserColumns.Country).value,
+    BaseLoc: titleCase(foundUser.getCell(officerUserColumns.BASE_LOC).value),
+    OrgKind: foundUser.getCell(officerUserColumns.org_kind).value,
+    EOPDate: foundUser.getCell(officerUserColumns.EOPDate).value,
+    LastName: titleCase(foundUser.getCell(officerUserColumns.Last_Name).value),
+    FirstName: titleCase(foundUser.getCell(officerUserColumns.First_name).value),
+    MiddleName: foundUser.getCell(officerUserColumns.Middle_Name).value,
+    UserType: "Officer",
+    lastModifiedAt: lastModifiedAt.toString(),
+  }
+}
+
+const createEnlistedUser = (foundUser: Row, lastModifiedAt: DateTime) => {
+  const grade = foundUser.getCell(enlistedUserColumns.Grade).value
+  const email = foundUser.getCell(enlistedUserColumns.ATP31).value?.toString()
+  return {
+    Rank: getEnlistedRankFromGrade(grade),
+    Grade: grade,
+    DutyTitle: titleCase(foundUser.getCell(enlistedUserColumns.DUTYTITLE).value),
+    AMU: foundUser.getCell(enlistedUserColumns.AMU).value,
+    DOD_ID: foundUser.getCell(enlistedUserColumns.DOD_ID).value,
+    Email: email ? email.toLowerCase() : '',
+    AFC291_01: foundUser.getCell(enlistedUserColumns.AFC291_01).value,
+    AMF: foundUser.getCell(enlistedUserColumns.AMF).value,
+    MPF: foundUser.getCell(enlistedUserColumns.MPF).value,
+    MajCom: titleCaseMajCom(foundUser.getCell(enlistedUserColumns.MAJCOM).value),
+    Country: foundUser.getCell(enlistedUserColumns.Country).value,
+    BaseLoc: titleCase(foundUser.getCell(enlistedUserColumns.BASE_LOC).value),
+    OrgType: foundUser.getCell(enlistedUserColumns.Org_type).value,
+    EOPDate: foundUser.getCell(enlistedUserColumns.EOPDate).value,
+    LastName: titleCase(foundUser.getCell(enlistedUserColumns.Last_Name).value),
+    FirstName: titleCase(foundUser.getCell(enlistedUserColumns.First_name).value),
+    MiddleName: foundUser.getCell(enlistedUserColumns.Middle_Name).value,
+    UserType: "Enlisted",
+    lastModifiedAt: lastModifiedAt.toString(),
+  }
+}
 
 export const resolvers = {
   Query: {
@@ -25,28 +82,7 @@ export const resolvers = {
       const foundUser = worksheet.getRow(foundUserRow);
 
       if (foundUserRow !== -1 && foundUser) {
-        const grade = foundUser.getCell(enlistedUserColumns.Grade).value;
-        return {
-          Rank: getEnlistedRankFromGrade(grade),
-          Grade: grade,
-          DutyTitle: foundUser.getCell(enlistedUserColumns.DUTYTITLE).value,
-          AMU: foundUser.getCell(enlistedUserColumns.AMU).value,
-          DOD_ID: foundUser.getCell(enlistedUserColumns.DOD_ID).value,
-          ATP31: foundUser.getCell(enlistedUserColumns.ATP31).value,
-          AFC291_01: foundUser.getCell(enlistedUserColumns.AFC291_01).value,
-          AMF: foundUser.getCell(enlistedUserColumns.AMF).value,
-          MPF: foundUser.getCell(enlistedUserColumns.MPF).value,
-          MajCom: foundUser.getCell(enlistedUserColumns.MAJCOM).value,
-          Country: foundUser.getCell(enlistedUserColumns.Country).value,
-          BaseLoc: foundUser.getCell(enlistedUserColumns.BASE_LOC).value,
-          OrgType: foundUser.getCell(enlistedUserColumns.Org_type).value,
-          EOPDate: foundUser.getCell(enlistedUserColumns.EOPDate).value,
-          LastName: foundUser.getCell(enlistedUserColumns.Last_Name).value,
-          FirstName: foundUser.getCell(enlistedUserColumns.First_name).value,
-          MiddleName: foundUser.getCell(enlistedUserColumns.Middle_Name).value,
-          UserType: "Enlisted",
-          lastModifiedAt: lastMod.toString(),
-        };
+        return createEnlistedUser(foundUser, lastMod)
       }
       return null;
     },
@@ -67,29 +103,7 @@ export const resolvers = {
       const foundUser = worksheet.getRow(foundUserRow);
 
       if (foundUserRow !== -1 && foundUser) {
-        const grade = foundUser.getCell(officerUserColumns.Grade).value;
-        return {
-          Rank: getOfficerRankFromGrade(grade),
-          Grade: grade,
-          ANB2: foundUser.getCell(officerUserColumns.ANB2).value,
-          DOD_ID: foundUser.getCell(officerUserColumns.DOD_ID).value,
-          ATP31: foundUser.getCell(officerUserColumns.ATP31).value,
-          CAS3: foundUser.getCell(officerUserColumns.CAS3).value,
-          AMF: foundUser.getCell(officerUserColumns.AMF).value,
-          DutyTitle: foundUser.getCell(officerUserColumns.DUTYTITLE).value,
-          MPF: foundUser.getCell(officerUserColumns.MPF).value,
-          CMD: foundUser.getCell(officerUserColumns.CMD).value,
-          MajCom: foundUser.getCell(officerUserColumns.MAJCOM).value,
-          Country: foundUser.getCell(officerUserColumns.Country).value,
-          BaseLoc: foundUser.getCell(officerUserColumns.BASE_LOC).value,
-          OrgKind: foundUser.getCell(officerUserColumns.org_kind).value,
-          EOPDate: foundUser.getCell(officerUserColumns.EOPDate).value,
-          LastName: foundUser.getCell(officerUserColumns.Last_Name).value,
-          FirstName: foundUser.getCell(officerUserColumns.First_name).value,
-          MiddleName: foundUser.getCell(officerUserColumns.Middle_Name).value,
-          UserType: "Officer",
-          lastModifiedAt: lastMod.toString(),
-        };
+        return createOfficerUser(foundUser, lastMod)
       }
       return null;
     },
@@ -111,33 +125,7 @@ export const resolvers = {
       const foundOfficerUser = officerWorksheet.getRow(foundOfficerUserRow);
 
       if (foundOfficerUserRow !== -1 && foundOfficerUser) {
-        const grade = foundOfficerUser.getCell(officerUserColumns.Grade).value;
-        return {
-          Rank: getOfficerRankFromGrade(grade),
-          Grade: grade,
-          ANB2: foundOfficerUser.getCell(officerUserColumns.ANB2).value,
-          DOD_ID: foundOfficerUser.getCell(officerUserColumns.DOD_ID).value,
-          ATP31: foundOfficerUser.getCell(officerUserColumns.ATP31).value,
-          CAS3: foundOfficerUser.getCell(officerUserColumns.CAS3).value,
-          AMF: foundOfficerUser.getCell(officerUserColumns.AMF).value,
-          DutyTitle: foundOfficerUser.getCell(officerUserColumns.DUTYTITLE)
-            .value,
-          MPF: foundOfficerUser.getCell(officerUserColumns.MPF).value,
-          CMD: foundOfficerUser.getCell(officerUserColumns.CMD).value,
-          MajCom: foundOfficerUser.getCell(officerUserColumns.MAJCOM).value,
-          Country: foundOfficerUser.getCell(officerUserColumns.Country).value,
-          BaseLoc: foundOfficerUser.getCell(officerUserColumns.BASE_LOC).value,
-          OrgKind: foundOfficerUser.getCell(officerUserColumns.org_kind).value,
-          EOPDate: foundOfficerUser.getCell(officerUserColumns.EOPDate).value,
-          LastName: foundOfficerUser.getCell(officerUserColumns.Last_Name)
-            .value,
-          FirstName: foundOfficerUser.getCell(officerUserColumns.First_name)
-            .value,
-          MiddleName: foundOfficerUser.getCell(officerUserColumns.Middle_Name)
-            .value,
-          UserType: "Officer",
-          lastModifiedAt: officerLastMod.toString(),
-        };
+        return createOfficerUser(foundOfficerUser, officerLastMod)
       }
       // If not found in officer list, check enlisted list
       const { worksheet: enlistedWorksheet, lastModifiedAt: enlistedLastMod } =
@@ -156,46 +144,15 @@ export const resolvers = {
       const foundEnlistedUser = enlistedWorksheet.getRow(foundEnlistedUserRow);
 
       if (foundEnlistedUserRow !== -1 && foundEnlistedUser) {
-        const grade = foundEnlistedUser.getCell(
-          enlistedUserColumns.Grade
-        ).value;
-        return {
-          Rank: getEnlistedRankFromGrade(grade),
-          Grade: grade,
-          DutyTitle: foundEnlistedUser.getCell(enlistedUserColumns.DUTYTITLE)
-            .value,
-          AMU: foundEnlistedUser.getCell(enlistedUserColumns.AMU).value,
-          DOD_ID: foundEnlistedUser.getCell(enlistedUserColumns.DOD_ID).value,
-          ATP31: foundEnlistedUser.getCell(enlistedUserColumns.ATP31).value,
-          AFC291_01: foundEnlistedUser.getCell(enlistedUserColumns.AFC291_01)
-            .value,
-          AMF: foundEnlistedUser.getCell(enlistedUserColumns.AMF).value,
-          MPF: foundEnlistedUser.getCell(enlistedUserColumns.MPF).value,
-          MajCom: foundEnlistedUser.getCell(enlistedUserColumns.MAJCOM).value,
-          Country: foundEnlistedUser.getCell(enlistedUserColumns.Country).value,
-          BaseLoc: foundEnlistedUser.getCell(enlistedUserColumns.BASE_LOC)
-            .value,
-          OrgType: foundEnlistedUser.getCell(enlistedUserColumns.Org_type)
-            .value,
-          EOPDate: foundEnlistedUser.getCell(enlistedUserColumns.EOPDate).value,
-          LastName: foundEnlistedUser.getCell(enlistedUserColumns.Last_Name)
-            .value,
-          FirstName: foundEnlistedUser.getCell(enlistedUserColumns.First_name)
-            .value,
-          MiddleName: foundEnlistedUser.getCell(
-            enlistedUserColumns.Middle_Name
-          ).value,
-          UserType: "Enlisted",
-          lastModifiedAt: enlistedLastMod.toString(),
-        };
+        return createEnlistedUser(foundEnlistedUser, enlistedLastMod)
       }
 
       // If not found in either list, return null
       return null;
     },
     getGuardianDirectory: async () => {
-      const { worksheet: officerWorksheet } = await getOfficerWorksheet();
-      const { worksheet: enlistedWorksheet } = await getEnlistedWorksheet();
+      const { worksheet: officerWorksheet, lastModifiedAt: officerLastMod } = await getOfficerWorksheet();
+      const { worksheet: enlistedWorksheet, lastModifiedAt: enlistedLastMod } = await getEnlistedWorksheet();
 
       const officerWorksheetValues = officerWorksheet.getColumn(
         officerUserColumns.DOD_ID
@@ -211,44 +168,17 @@ export const resolvers = {
       // Initializing at 2 to skip the header row
       for (let i = 2; i < officerWorksheetValues.length; i++) {
         const officerUser = officerWorksheet.getRow(i);
-        officerGuardianDirectoryUsers.push({
-          DOD_ID: officerUser.getCell(officerUserColumns.DOD_ID).value,
-          FirstName: officerUser.getCell(officerUserColumns.First_name).value,
-          MiddleName: officerUser.getCell(officerUserColumns.Middle_Name)
-            .value,
-          LastName: officerUser.getCell(officerUserColumns.Last_Name).value,
-          Email: officerUser.getCell(officerUserColumns.ATP31).value,
-          Rank: getOfficerRankFromGrade(
-            officerUser.getCell(officerUserColumns.Grade).value
-          ),
-          DutyTitle: officerUser.getCell(officerUserColumns.DUTYTITLE).value,
-          BaseLoc: officerUser.getCell(officerUserColumns.BASE_LOC).value,
-          MajCom: officerUser.getCell(officerUserColumns.MAJCOM).value,
-          OrgType: officerUser.getCell(officerUserColumns.Org_type).value,
-          OrgKind: officerUser.getCell(officerUserColumns.org_kind).value,
-        });
+        officerGuardianDirectoryUsers.push(
+          createOfficerUser(officerUser, officerLastMod)
+        );
       }
 
       // Initializing at 2 to skip the header row
       for (let i = 2; i < enlistedWorksheetValues.length; i++) {
-        const enlistedUser = enlistedWorksheet.getRow(i);
-        enlistedGuardianDirectoryUsers.push({
-          DOD_ID: enlistedUser.getCell(enlistedUserColumns.DOD_ID).value,
-          FirstName: enlistedUser.getCell(enlistedUserColumns.First_name)
-            .value,
-          MiddleName: enlistedUser.getCell(enlistedUserColumns.Middle_Name)
-            .value,
-          LastName: enlistedUser.getCell(enlistedUserColumns.Last_Name).value,
-          Email: enlistedUser.getCell(enlistedUserColumns.ATP31).value,
-          Rank: getEnlistedRankFromGrade(
-            enlistedUser.getCell(enlistedUserColumns.Grade).value
-          ),
-          DutyTitle: enlistedUser.getCell(enlistedUserColumns.DUTYTITLE).value,
-          BaseLoc: enlistedUser.getCell(enlistedUserColumns.BASE_LOC).value,
-          MajCom: enlistedUser.getCell(enlistedUserColumns.MAJCOM).value,
-          OrgType: enlistedUser.getCell(enlistedUserColumns.Org_type).value,
-          OrgKind: enlistedUser.getCell(enlistedUserColumns.org_kind).value,
-        });
+        const enlistedUser = enlistedWorksheet.getRow(i)
+        enlistedGuardianDirectoryUsers.push(
+          createEnlistedUser(enlistedUser, enlistedLastMod)
+        )
       }
 
       const sortedArray = [

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -249,10 +249,20 @@ export const resolvers = {
         });
       }
 
-      return [
+      const sortedArray = [
         ...officerGuardianDirectoryUsers,
         ...enlistedGuardianDirectoryUsers,
-      ];
+      ].sort((a, b) => {
+        if (a.Last_Name! < b.Last_Name!) {
+          return -1;
+        }
+        if (a.Last_Name! > b.Last_Name!) {
+          return 1;
+        }
+        return 0;
+      });
+
+      return sortedArray;
     },
   },
 };

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -212,6 +212,7 @@ export const resolvers = {
       for (let i = 2; i < officerWorksheetValues.length; i++) {
         const officerUser = officerWorksheet.getRow(i);
         officerGuardianDirectoryUsers.push({
+          DOD_ID: officerUser.getCell(officerUserColumns.DOD_ID).value,
           First_name: officerUser.getCell(officerUserColumns.First_name).value,
           Middle_Name: officerUser.getCell(officerUserColumns.Middle_Name)
             .value,
@@ -232,6 +233,7 @@ export const resolvers = {
       for (let i = 2; i < enlistedWorksheetValues.length; i++) {
         const enlistedUser = enlistedWorksheet.getRow(i);
         enlistedGuardianDirectoryUsers.push({
+          DOD_ID: enlistedUser.getCell(officerUserColumns.DOD_ID).value,
           First_name: enlistedUser.getCell(enlistedUserColumns.First_name)
             .value,
           Middle_Name: enlistedUser.getCell(enlistedUserColumns.Middle_Name)

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -11,37 +11,37 @@ export const typeDefs = gql`
   type User {
     Rank: Rank
     Grade: String
-    DUTYTITLE: String
+    DutyTitle: String
     AMU: String
     DOD_ID: String
     ATP31: String
     AFC291_01: String
     AMF: String
     MPF: String
-    MAJCOM: String
+    MajCom: String
     Country: String
-    BASE_LOC: String
-    Org_type: String
+    BaseLoc: String
+    OrgType: String
     EOPDate: String
-    Last_Name: String
-    First_name: String
-    Middle_Name: String
+    LastName: String
+    FirstName: String
+    MiddleName: String
     ANB2: String
     CAS3: String
     CMD: String
-    org_kind: String
-    userType: String
+    OrgKind: String
+    UserType: String
     lastModifiedAt: String
   }
 
   type GuardianDirectoryUser {
     DOD_ID: String
-    First_name: String
-    Middle_Name: String
-    Last_Name: String
+    FirstName: String
+    MiddleName: String
+    LastName: String
     Email: String
     Rank: Rank
-    Duty: String
+    DutyTitle: String
     BaseLoc: String
     MajCom: String
     OrgType: String

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2,9 +2,9 @@ import { gql } from "graphql-tag";
 
 export const typeDefs = gql`
   type Rank {
-    Title: String,
-    Abbreviation: String,
-    Grade: String,
+    Title: String
+    Abbreviation: String
+    Grade: String
     GradeId: String
   }
 
@@ -34,6 +34,19 @@ export const typeDefs = gql`
     lastModifiedAt: String
   }
 
+  type GuardianDirectoryUser {
+    First_name: String
+    Middle_Name: String
+    Last_Name: String
+    Email: String
+    Rank: Rank
+    Duty: String
+    BaseLoc: String
+    MajCom: String
+    OrgType: String
+    OrgKind: String
+  }
+
   type Query {
     getEnlistedUser(id: String!): User
   }
@@ -44,5 +57,9 @@ export const typeDefs = gql`
 
   type Query {
     getUser(id: String!): User
+  }
+
+  type Query {
+    getGuardianDirectory: [GuardianDirectoryUser]
   }
 `;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -35,6 +35,7 @@ export const typeDefs = gql`
   }
 
   type GuardianDirectoryUser {
+    DOD_ID: String
     First_name: String
     Middle_Name: String
     Last_Name: String
@@ -49,17 +50,8 @@ export const typeDefs = gql`
 
   type Query {
     getEnlistedUser(id: String!): User
-  }
-
-  type Query {
     getOfficerUser(id: String!): User
-  }
-
-  type Query {
     getUser(id: String!): User
-  }
-
-  type Query {
     getGuardianDirectory: [GuardianDirectoryUser]
   }
 `;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -14,7 +14,6 @@ export const typeDefs = gql`
     DutyTitle: String
     AMU: String
     DOD_ID: String
-    ATP31: String
     AFC291_01: String
     AMF: String
     MPF: String
@@ -26,6 +25,7 @@ export const typeDefs = gql`
     LastName: String
     FirstName: String
     MiddleName: String
+    Email: String
     ANB2: String
     CAS3: String
     CMD: String
@@ -34,24 +34,10 @@ export const typeDefs = gql`
     lastModifiedAt: String
   }
 
-  type GuardianDirectoryUser {
-    DOD_ID: String
-    FirstName: String
-    MiddleName: String
-    LastName: String
-    Email: String
-    Rank: Rank
-    DutyTitle: String
-    BaseLoc: String
-    MajCom: String
-    OrgType: String
-    OrgKind: String
-  }
-
   type Query {
     getEnlistedUser(id: String!): User
     getOfficerUser(id: String!): User
     getUser(id: String!): User
-    getGuardianDirectory: [GuardianDirectoryUser]
+    getGuardianDirectory: [User]
   }
 `;


### PR DESCRIPTION
# SC-2303

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

Related PR: https://github.com/USSF-ORBIT/ussf-portal-client/pull/1127

## Proposed changes

Normalizes data, minor refactor so all resolvers use the same helper to generate user objects, and added build cache as an artifact so it can be used by the e2e tests.

<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

Due to changes needed in the shared e2e build workflow the e2e tests won't run for this branch until after those updates are merged. You can see that the tests are green though in this branch https://github.com/USSF-ORBIT/ussf-portal/pull/324

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

---

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

---
