### PR TITLE
ci: allow release please reusable workflow to use org secrets

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,3 +17,4 @@ jobs:
     with:
       release-type: node
       package-name: ussf-personnel-api
+    secrets: inherit


### PR DESCRIPTION
<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
- Now that we have created a GH machine user and a Personal Access Token for Release-Please, we have to instruct the reusable workflow caller to allow the called release-please workflow to inherit secrets from the caller. This will give the reusable Release Please workflow the access to the PAT.

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

---

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

---
