### PR TITLE
feat: Add search resolver for Guardian Directory

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,27 @@
+# Dependency directories
+node_modules/
+.awcache
+.DS_Store
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# Optional eslint cache
+.eslintcache
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env
+.envrc.local
+
+# Generated files
+CHANGELOG.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+    "trailingComma": "es5",
+    "semi": false,
+    "singleQuote": true,
+    "bracketSameLine": true
+  }

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,5 +1,5 @@
-import { DateTime } from "luxon";
-import { enlistedUserColumns, officerUserColumns } from "./constants.js";
+import { DateTime } from 'luxon'
+import { enlistedUserColumns, officerUserColumns } from './constants.js'
 import {
   getEnlistedRankFromGrade,
   getEnlistedWorksheet,
@@ -7,8 +7,8 @@ import {
   getOfficerWorksheet,
   titleCase,
   titleCaseMajCom,
-} from "./helpers.js";
-import { Row } from "exceljs";
+} from './helpers.js'
+import { Row } from 'exceljs'
 
 const createOfficerUser = (foundUser: Row, lastModifiedAt: DateTime) => {
   const grade = foundUser.getCell(officerUserColumns.Grade).value
@@ -30,9 +30,11 @@ const createOfficerUser = (foundUser: Row, lastModifiedAt: DateTime) => {
     OrgKind: foundUser.getCell(officerUserColumns.org_kind).value,
     EOPDate: foundUser.getCell(officerUserColumns.EOPDate).value,
     LastName: titleCase(foundUser.getCell(officerUserColumns.Last_Name).value),
-    FirstName: titleCase(foundUser.getCell(officerUserColumns.First_name).value),
+    FirstName: titleCase(
+      foundUser.getCell(officerUserColumns.First_name).value
+    ),
     MiddleName: foundUser.getCell(officerUserColumns.Middle_Name).value,
-    UserType: "Officer",
+    UserType: 'Officer',
     lastModifiedAt: lastModifiedAt.toString(),
   }
 }
@@ -43,22 +45,28 @@ const createEnlistedUser = (foundUser: Row, lastModifiedAt: DateTime) => {
   return {
     Rank: getEnlistedRankFromGrade(grade),
     Grade: grade,
-    DutyTitle: titleCase(foundUser.getCell(enlistedUserColumns.DUTYTITLE).value),
+    DutyTitle: titleCase(
+      foundUser.getCell(enlistedUserColumns.DUTYTITLE).value
+    ),
     AMU: foundUser.getCell(enlistedUserColumns.AMU).value,
     DOD_ID: foundUser.getCell(enlistedUserColumns.DOD_ID).value,
     Email: email ? email.toLowerCase() : '',
     AFC291_01: foundUser.getCell(enlistedUserColumns.AFC291_01).value,
     AMF: foundUser.getCell(enlistedUserColumns.AMF).value,
     MPF: foundUser.getCell(enlistedUserColumns.MPF).value,
-    MajCom: titleCaseMajCom(foundUser.getCell(enlistedUserColumns.MAJCOM).value),
+    MajCom: titleCaseMajCom(
+      foundUser.getCell(enlistedUserColumns.MAJCOM).value
+    ),
     Country: foundUser.getCell(enlistedUserColumns.Country).value,
     BaseLoc: titleCase(foundUser.getCell(enlistedUserColumns.BASE_LOC).value),
     OrgType: foundUser.getCell(enlistedUserColumns.Org_type).value,
     EOPDate: foundUser.getCell(enlistedUserColumns.EOPDate).value,
     LastName: titleCase(foundUser.getCell(enlistedUserColumns.Last_Name).value),
-    FirstName: titleCase(foundUser.getCell(enlistedUserColumns.First_name).value),
+    FirstName: titleCase(
+      foundUser.getCell(enlistedUserColumns.First_name).value
+    ),
     MiddleName: foundUser.getCell(enlistedUserColumns.Middle_Name).value,
-    UserType: "Enlisted",
+    UserType: 'Enlisted',
     lastModifiedAt: lastModifiedAt.toString(),
   }
 }
@@ -67,110 +75,111 @@ export const resolvers = {
   Query: {
     getEnlistedUser: async (_: any, { id }: { id: string }) => {
       const { worksheet, lastModifiedAt: lastMod } =
-        await getEnlistedWorksheet();
+        await getEnlistedWorksheet()
 
       let worksheetValues = worksheet.getColumn(
         enlistedUserColumns.DOD_ID
-      ).values;
+      ).values
 
       worksheetValues = worksheetValues.map((value) => {
-        return value?.toString().trim();
-      });
+        return value?.toString().trim()
+      })
 
       // Find the index of the DOD_ID we're looking for in the DOD_ID column
-      const foundUserRow = worksheetValues.indexOf(id);
-      const foundUser = worksheet.getRow(foundUserRow);
+      const foundUserRow = worksheetValues.indexOf(id)
+      const foundUser = worksheet.getRow(foundUserRow)
 
       if (foundUserRow !== -1 && foundUser) {
         return createEnlistedUser(foundUser, lastMod)
       }
-      return null;
+      return null
     },
     getOfficerUser: async (_: any, { id }: { id: string }) => {
-      const { worksheet, lastModifiedAt: lastMod } =
-        await getOfficerWorksheet();
+      const { worksheet, lastModifiedAt: lastMod } = await getOfficerWorksheet()
 
       let officerWorksheetValues = worksheet.getColumn(
         officerUserColumns.DOD_ID
-      ).values;
+      ).values
 
       officerWorksheetValues = officerWorksheetValues.map((value) => {
-        return value?.toString().trim();
-      });
+        return value?.toString().trim()
+      })
 
       // Find the index of the DOD_ID we're looking for in the DOD_ID column
-      const foundUserRow = officerWorksheetValues.indexOf(id);
-      const foundUser = worksheet.getRow(foundUserRow);
+      const foundUserRow = officerWorksheetValues.indexOf(id)
+      const foundUser = worksheet.getRow(foundUserRow)
 
       if (foundUserRow !== -1 && foundUser) {
         return createOfficerUser(foundUser, lastMod)
       }
-      return null;
+      return null
     },
     getUser: async (_: any, { id }: { id: string }) => {
       // First check officer list
       const { worksheet: officerWorksheet, lastModifiedAt: officerLastMod } =
-        await getOfficerWorksheet();
+        await getOfficerWorksheet()
 
       let worksheetValues = officerWorksheet.getColumn(
         officerUserColumns.DOD_ID
-      ).values;
+      ).values
 
       worksheetValues = worksheetValues.map((value) => {
-        return value?.toString().trim();
-      });
+        return value?.toString().trim()
+      })
 
       // Find the index of the DOD_ID we're looking for in the DOD_ID column
-      const foundOfficerUserRow = worksheetValues.indexOf(id);
-      const foundOfficerUser = officerWorksheet.getRow(foundOfficerUserRow);
+      const foundOfficerUserRow = worksheetValues.indexOf(id)
+      const foundOfficerUser = officerWorksheet.getRow(foundOfficerUserRow)
 
       if (foundOfficerUserRow !== -1 && foundOfficerUser) {
         return createOfficerUser(foundOfficerUser, officerLastMod)
       }
       // If not found in officer list, check enlisted list
       const { worksheet: enlistedWorksheet, lastModifiedAt: enlistedLastMod } =
-        await getEnlistedWorksheet();
+        await getEnlistedWorksheet()
 
       let enlistedWorksheetValues = enlistedWorksheet.getColumn(
         enlistedUserColumns.DOD_ID
-      ).values;
+      ).values
 
       enlistedWorksheetValues = enlistedWorksheetValues.map((value) => {
-        return value?.toString().trim();
-      });
+        return value?.toString().trim()
+      })
 
       // Find the index of the DOD_ID we're looking for in the DOD_ID column
-      const foundEnlistedUserRow = enlistedWorksheetValues.indexOf(id);
-      const foundEnlistedUser = enlistedWorksheet.getRow(foundEnlistedUserRow);
+      const foundEnlistedUserRow = enlistedWorksheetValues.indexOf(id)
+      const foundEnlistedUser = enlistedWorksheet.getRow(foundEnlistedUserRow)
 
       if (foundEnlistedUserRow !== -1 && foundEnlistedUser) {
         return createEnlistedUser(foundEnlistedUser, enlistedLastMod)
       }
 
       // If not found in either list, return null
-      return null;
+      return null
     },
     getGuardianDirectory: async () => {
-      const { worksheet: officerWorksheet, lastModifiedAt: officerLastMod } = await getOfficerWorksheet();
-      const { worksheet: enlistedWorksheet, lastModifiedAt: enlistedLastMod } = await getEnlistedWorksheet();
+      const { worksheet: officerWorksheet, lastModifiedAt: officerLastMod } =
+        await getOfficerWorksheet()
+      const { worksheet: enlistedWorksheet, lastModifiedAt: enlistedLastMod } =
+        await getEnlistedWorksheet()
 
       const officerWorksheetValues = officerWorksheet.getColumn(
         officerUserColumns.DOD_ID
-      ).values;
+      ).values
 
       const enlistedWorksheetValues = enlistedWorksheet.getColumn(
         enlistedUserColumns.DOD_ID
-      ).values;
+      ).values
 
-      const officerGuardianDirectoryUsers = [];
-      const enlistedGuardianDirectoryUsers = [];
+      const officerGuardianDirectoryUsers = []
+      const enlistedGuardianDirectoryUsers = []
 
       // Initializing at 2 to skip the header row
       for (let i = 2; i < officerWorksheetValues.length; i++) {
-        const officerUser = officerWorksheet.getRow(i);
+        const officerUser = officerWorksheet.getRow(i)
         officerGuardianDirectoryUsers.push(
           createOfficerUser(officerUser, officerLastMod)
-        );
+        )
       }
 
       // Initializing at 2 to skip the header row
@@ -186,15 +195,98 @@ export const resolvers = {
         ...enlistedGuardianDirectoryUsers,
       ].sort((a, b) => {
         if (a.LastName! < b.LastName!) {
-          return -1;
+          return -1
         }
         if (a.LastName! > b.LastName!) {
-          return 1;
+          return 1
         }
-        return 0;
-      });
+        return 0
+      })
 
-      return sortedArray;
+      return sortedArray
+    },
+    searchGuardianDirectory: async (_: any, { search }: { search: string }) => {
+      try {
+        const { worksheet: officerWorksheet, lastModifiedAt: officerLastMod } =
+          await getOfficerWorksheet()
+        const {
+          worksheet: enlistedWorksheet,
+          lastModifiedAt: enlistedLastMod,
+        } = await getEnlistedWorksheet()
+
+        const searchTerms = search.trim().split(' ')
+        const searchResults: any = []
+
+        let found = false
+        let foundOfficerUser
+        let foundEnlistedUser
+
+        // Search officers spreadsheet for any cell that contains any of the search terms
+        for (let i = 2; i < officerWorksheet.rowCount; i++) {
+          const row = officerWorksheet.getRow(i)
+
+          for (let j = 1; j < row.cellCount; j++) {
+            const cell = row.getCell(j)
+
+            if (cell.value) {
+              // Normalize text from cell
+              const cellValue = cell.value.toString().toLowerCase()
+              // Check if cell value includes any of the search terms
+              if (
+                searchTerms.some((term) =>
+                  cellValue.includes(term.toLowerCase())
+                )
+              ) {
+                foundOfficerUser = officerWorksheet.getRow(i)
+                found = true
+                const user = createOfficerUser(foundOfficerUser, officerLastMod)
+                searchResults.push(user)
+                break
+              }
+            }
+          }
+          if (found) {
+            found = false
+            continue
+          }
+        }
+
+        // Search enlisted spreadsheet for any cell that contains any of the search terms
+        for (let i = 2; i < enlistedWorksheet.rowCount; i++) {
+          const row = enlistedWorksheet.getRow(i)
+
+          for (let j = 1; j < row.cellCount; j++) {
+            const cell = row.getCell(j)
+
+            if (cell.value) {
+              // Normalize text from cel
+              const cellValue = cell.value.toString().toLowerCase()
+              // Check if cell value includes any of the search terms
+              if (
+                searchTerms.some((term) =>
+                  cellValue.includes(term.toLowerCase())
+                )
+              ) {
+                foundEnlistedUser = enlistedWorksheet.getRow(i)
+                found = true
+                const user = createEnlistedUser(
+                  foundEnlistedUser,
+                  enlistedLastMod
+                )
+                searchResults.push(user)
+                break
+              }
+            }
+          }
+          if (found) {
+            found = false
+            continue
+          }
+        }
+        return searchResults
+      } catch (error) {
+        console.error('Error in guardianDirectorySearch:', error)
+      }
     },
   },
-};
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -39,5 +39,6 @@ export const typeDefs = gql`
     getOfficerUser(id: String!): User
     getUser(id: String!): User
     getGuardianDirectory: [User]
+    searchGuardianDirectory(search: String!): [User]
   }
 `;


### PR DESCRIPTION
# SC-2474

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->
## Related PRs
https://github.com/USSF-ORBIT/ussf-portal/pull/347
https://github.com/USSF-ORBIT/ussf-portal-client/pull/1183


## Proposed changes

* Adds prettier file because my nested for-loops needed help
* Adds resolver to search spreadsheet and return results

## Reviewer notes

You can test this standalone by running `yarn dev`, going to `localhost:4000/api/graphql`, and running the query:

Query:

```
query SearchGuardianDirectory($search: String!) {
  searchGuardianDirectory(search: $search) {
    FirstName
    LastName
    DOD_ID
    Email
    lastModifiedAt
  }
}
```
Variable:
```

{
  "search": "bernadette king"
}
```

Try with a variety of query strings. 

## Setup

In addition to testing the service locally, check out the ussf-portal-client PR for the entire flow.
https://github.com/USSF-ORBIT/ussf-portal-client/pull/1183