### PR TITLE
chore: add the okay-to-merge label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,7 @@ pull_request_rules:
     conditions:
       - and:
         - "label!=no-merge"
+        - "label=okay-to-merge"
         - and:
           - author!=dependabot[bot] # if author is not dependabot
           - author!=renovate[bot] # if author is not renovatebot


### PR DESCRIPTION
# SC-3133
 
Add the okay-to-merge label which will not allow mergify to merge until it is present.